### PR TITLE
feat: update to .NET 11 RC 1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:5-24-bookworm@sha256:d7e88ca9d7e48412c4f9afed316dac5a830e194c10bf0bea5912f524e14925dc
 
-COPY --from=mcr.microsoft.com/dotnet/nightly/sdk:11.0.100-preview.5@sha256:79a1155bef1000d32505ba0a59ef7068b6c939324c4dc8e7c4f6f67d1a5c2e47 /usr/share/dotnet /usr/share/dotnet
+COPY --from=mcr.microsoft.com/dotnet/nightly/sdk:11.0.100-rc.1@sha256:cd72ff9fb53f2197e7de762adf66417e49b22bd7955913f078b32c5b209ee1cc /usr/share/dotnet /usr/share/dotnet

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,17 +17,17 @@
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Flagd" Version="13.4.0" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Minio" Version="13.4.0" />
     <PackageVersion Include="Duende.AccessTokenManagement.OpenIdConnect" Version="4.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="11.0.0-preview.7.26381.103" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="11.0.0-preview.7.26381.103" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="11.0.0-preview.7.26381.103" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="11.0.0-preview.7.26381.103" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="11.0.0-preview.7.26381.103">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="11.0.0-rc.1.26425.128" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="11.0.0-rc.1.26425.128" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="11.0.0-rc.1.26425.128" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="11.0.0-rc.1.26425.128" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="11.0.0-rc.1.26425.128">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="11.0.0-rc.1.26425.128" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.9.0" />
@@ -35,7 +35,7 @@
     <PackageVersion Include="Microsoft.Kiota.Bundle" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-rc.1.26425.128" />
     <PackageVersion Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.3.1" />
     <PackageVersion Include="OpenFeature" Version="2.14.1" />
     <PackageVersion Include="OpenFeature.Contrib.Hooks.Otel" Version="0.2.1" />

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ graph TD
 
 ## Prerequisites
 
-- [.NET 11 Preview 6 SDK](https://dotnet.microsoft.com/en-us/download) (the repository is pinned to `11.0.100-preview.6.26359.118` in `global.json`)
+- [.NET 11 RC 1 SDK](https://dotnet.microsoft.com/en-us/download) (the repository is pinned to `11.0.100-rc.1.26425.128` in `global.json`)
 - [`pnpm`](https://pnpm.io/)
 - Containerization tool ([podman](https://podman.io/), [docker](https://www.docker.com/products/docker-desktop/), etc)
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "11.0.100-preview.7.26381.103",
+		"version": "11.0.100-rc.1.26425.128",
 		"allowPrerelease": true,
 		"rollForward": "latestFeature"
 	},


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.

## Contribution Type

What kind of change does this PR introduce?

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:

## Description

Updates the repository from .NET 11 preview 7 to .NET 11 RC 1 (released 2026-09-08). Follows the same pattern as #129.

### What is the current behavior (add a screenshot if applicable)?

The repo is pinned to SDK `11.0.100-preview.7.26381.103` and the Microsoft framework packages to `11.0.0-preview.7.26381.103`. The devcontainer still pulls the preview 5 SDK image, and the README prerequisites line still mentions preview 6.

### What is the new behavior?

| File | Change |
|---|---|
| `global.json` | SDK pin → `11.0.100-rc.1.26425.128` |
| `Directory.Packages.props` | `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Authentication.OpenIdConnect`, `Microsoft.AspNetCore.OpenApi`, `Microsoft.EntityFrameworkCore.Tools`, `Microsoft.Extensions.ApiDescription.Server`, `Microsoft.Extensions.Hosting`, `Microsoft.AspNetCore.Mvc.Testing` → `11.0.0-rc.1.26425.128` |
| `.devcontainer/Dockerfile` | SDK image `mcr.microsoft.com/dotnet/nightly/sdk:11.0.100-preview.5` → `11.0.100-rc.1`, digest pinned to the multi-arch manifest list (linux/amd64, linux/arm64, linux/arm) |
| `README.md` | Prerequisites line now says RC 1 with the correct `global.json` pin |

CI needs no changes — both workflows use `actions/setup-dotnet` with `global-json-file`.

## Additional Notes

Verified locally with the RC 1 SDK:

- `dotnet build --configuration Release --no-incremental` — succeeded with zero warnings (`TreatWarningsAsErrors` + `AnalysisMode=All` are on, so no new RC 1 analyzer rules fire)
- `dotnet test --no-build --configuration Release` — 37/37 passed, including the Testcontainers-backed integration tests
- Output `runtimeconfig.json` / `deps.json` reference `11.0.0-rc.1.26425.128` with no preview 7 leftovers
- The build-time generated `docs/openapi/Sandbox.ApiService.json` is byte-identical under RC 1, so unlike #129 the Kiota client did not need regenerating

Reviewers need the RC 1 SDK installed locally; `rollForward: latestFeature` will not roll a preview SDK forward to an RC.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
